### PR TITLE
prevent Library Items to be dragged out of the Window

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -135,6 +135,10 @@ body {
 	-webkit-user-drag: none;
 	-webkit-app-region: no-drag;
 }
+
+.no-drag {
+  -webkit-user-drag: none;
+}
 </style>
 <style scoped>
 .topbar {

--- a/src/views/Library.vue
+++ b/src/views/Library.vue
@@ -28,7 +28,7 @@
 					<img
 						v-if="imageExists(item.name)"
 						v-bind:src="calcImagePath(item.name)"
-						class="thumbnail"
+						class="thumbnail no-drag"
 					/>
 					<div v-else class="thumbnail" />
 					<!-- <span class="thumbnail"></span> -->


### PR DESCRIPTION
Currently it is possible to drag nodes from the Library on to the desktop or a file explorer. This saves the thumbnail image to that location. Discord msg with bug: [Click me :)](https://discord.com/channels/769312171266932786/801206042120814601/842834481219239948)