### PR TITLE
Follow up to #43

### DIFF
--- a/src/lib/scene.ts
+++ b/src/lib/scene.ts
@@ -452,11 +452,8 @@ export class NodeScene {
 	/**
 	 * Checks if adding a hypothetical connection, the graph would remain to be a directed acyclic graph (DAG).
 	 *
-	 * Note: This method assumes the graph is a DAG prior to calling this method,
-	 *       it could return true if the graph wasn't to begin with.
-	 *
-	 * @param leftNode left node of the new connection
-	 * @param rightNode right node of the new connection
+	 * @param leftNode input node of the new connection
+	 * @param rightNode output node of the new connection
 	 * @returns
 	 */
 	remainsDAG(leftNode: NodeGraphicsItem, rightNode: NodeGraphicsItem) {
@@ -475,6 +472,7 @@ export class NodeScene {
 						return false;
 					} else {
 						expanding.push(nodeB);
+						checked.add(nodeA);
 					}
 				}
 			}

--- a/src/lib/scene/socketgraphicsitem.ts
+++ b/src/lib/scene/socketgraphicsitem.ts
@@ -207,20 +207,29 @@ export class SocketGraphicsItem extends GraphicsItem {
 			// for other conditions (existing connection being removed, etc...)
 			//
 			// this means one socket has to be SocketType.Out and the other should be SocketType.In
-			if (
-				closeSock &&
-				(
-					(this.socketType == SocketType.Out && closeSock.socketType == SocketType.In
-						&& !this.scene.remainsDAG(this.node, closeSock.node)) ||
-					(this.socketType == SocketType.In && closeSock.socketType == SocketType.Out
-						&& !this.scene.remainsDAG(closeSock.node, this.node))
-				)
-			) {
-				this.hit = false;
-				this.hitSocket = null;
-				this.hitConnection = null;
+			let remainsDAG = false;
 
-				return;
+			if (closeSock) {
+				if (
+					this.socketType == SocketType.Out &&
+					closeSock.socketType == SocketType.In
+				)
+					remainsDAG =
+						this.scene.remainsDAG(this.node, closeSock.node) || remainsDAG;
+				else if (
+					this.socketType == SocketType.In &&
+					closeSock.socketType == SocketType.Out
+				)
+					remainsDAG =
+						this.scene.remainsDAG(closeSock.node, this.node) || remainsDAG;
+
+				if (!remainsDAG) {
+					this.hit = false;
+					this.hitSocket = null;
+					this.hitConnection = null;
+
+					return;
+				}
 			}
 
 			// remove previous connection

--- a/src/lib/scene/socketgraphicsitem.ts
+++ b/src/lib/scene/socketgraphicsitem.ts
@@ -202,22 +202,25 @@ export class SocketGraphicsItem extends GraphicsItem {
 				mouseY
 			);
 
+			// check if a cyclical connection is about to be added,
 			// this can only happen when forming a new connection so no need to check
 			// for other conditions (existing connection being removed, etc...)
-			// this means this socket type should be SocketType.Out and the other
-			// should be SocketType.In
+			//
+			// this means one socket has to be SocketType.Out and the other should be SocketType.In
 			if (
 				closeSock &&
-				this.socketType == SocketType.Out &&
-				closeSock.socketType == SocketType.In
+				(
+					(this.socketType == SocketType.Out && closeSock.socketType == SocketType.In
+						&& !this.scene.remainsDAG(this.node, closeSock.node)) ||
+					(this.socketType == SocketType.In && closeSock.socketType == SocketType.Out
+						&& !this.scene.remainsDAG(closeSock.node, this.node))
+				)
 			) {
-				if (!this.scene.remainsDAG(this.node, closeSock.node)) {
-					this.hit = false;
-					this.hitSocket = null;
-					this.hitConnection = null;
+				this.hit = false;
+				this.hitSocket = null;
+				this.hitConnection = null;
 
-					return;
-				}
+				return;
 			}
 
 			// remove previous connection


### PR DESCRIPTION
I agree that moving the check there is the right thing to do, however the way it was implemented it wouldn't detect cycles introduced by connecting an `in` socket to an `out` socket. Causing #28 again. This should be addressed by this commit.

And I made sure to add the previously checked nodes to the checked array in `remainsDAG`. _Should this function ever turn out to be a bottleneck performance wise, I guess the `checked` set should be removed, but at least the loop will always terminate in finite time like this (otherwise if there was a cycle to begin with it could potentially loop forever in this method, arguably it will still lead to a problem elsewhere when evaluating the nodes but at least it's one less potential source of problems)._